### PR TITLE
Fix Searched User Username Comparisons

### DIFF
--- a/src/features/userSearch/usersSlice/fetchUserThunk.ts
+++ b/src/features/userSearch/usersSlice/fetchUserThunk.ts
@@ -89,7 +89,7 @@ export const fetchUser = createAsyncThunk<
     condition: (username: string, { getState }) => {
       const { users } = getState();
       const hasUserWithUsername: boolean = users.searchedUsers.some(
-        (user) => user.login === username
+        (user) => user.login.toLowerCase() === username.toLowerCase()
       );
 
       // return false to cancel action.
@@ -139,11 +139,11 @@ const onRejectedByCondition: ActionHandler<RejectedAction> = (
   const searchedUsername = action.meta.arg;
 
   const searchedUser = searchedUsers.find(
-    (user) => user.login === searchedUsername
+    (user) => user.login.toLowerCase() === searchedUsername.toLowerCase()
   ) as PublicGitHubUser;
 
   const otherUsers = searchedUsers.filter(
-    (user) => user.login !== searchedUsername
+    (user) => user.login.toLowerCase() !== searchedUsername.toLowerCase()
   );
 
   return {


### PR DESCRIPTION
Change to compare the lowercase values of searched username.

This fixed an issue that caused duplicated user to show in the cards collection.